### PR TITLE
Non used fonts removed from CSS

### DIFF
--- a/FORD/Vinterhjältar_2024_Q1/studiofiler/2024_vh_250x600/src/styles.css
+++ b/FORD/Vinterhjältar_2024_Q1/studiofiler/2024_vh_250x600/src/styles.css
@@ -2,21 +2,12 @@
   box-sizing: border-box;
 } 
 @font-face {
-  font-family: FordAntennaCond-Regular;
-  src: url("https://s0.2mdn.net/creatives/assets/4977512/FordAntennaCond-Regular.otf");
-}
-@font-face {
   font-family: FordAntennaCond-Black;
   src: url("https://s0.2mdn.net/creatives/assets/4977512/FordAntennaCond-Black.otf");
 }
 @font-face {
   font-family: FordAntennaCond-Light;
   src: url("https://s0.2mdn.net/creatives/assets/4977512/FordAntennaCond-Light.otf");
-}
-
-@font-face {
-  font-family: FordAntennaCond-Bold;
-  src: url("https://s0.2mdn.net/creatives/assets/4977512/FordAntennaCond-Bold.otf");
 }
 @font-face {
   font-family: FordAntenna-Regular;

--- a/FORD/Vinterhjältar_2024_Q1/studiofiler/2024_vh_300x600/src/styles.css
+++ b/FORD/Vinterhjältar_2024_Q1/studiofiler/2024_vh_300x600/src/styles.css
@@ -2,21 +2,12 @@
   box-sizing: border-box;
 } 
 @font-face {
-  font-family: FordAntennaCond-Regular;
-  src: url("https://s0.2mdn.net/creatives/assets/4977512/FordAntennaCond-Regular.otf");
-}
-@font-face {
   font-family: FordAntennaCond-Black;
   src: url("https://s0.2mdn.net/creatives/assets/4977512/FordAntennaCond-Black.otf");
 }
 @font-face {
   font-family: FordAntennaCond-Light;
   src: url("https://s0.2mdn.net/creatives/assets/4977512/FordAntennaCond-Light.otf");
-}
-
-@font-face {
-  font-family: FordAntennaCond-Bold;
-  src: url("https://s0.2mdn.net/creatives/assets/4977512/FordAntennaCond-Bold.otf");
 }
 @font-face {
   font-family: FordAntenna-Regular;


### PR DESCRIPTION
250x600 and 300x600 included fonts that were not in use and took up unnecessary space. These are now removed